### PR TITLE
fix: support windows path

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -75,7 +75,7 @@ function canRunnerRun(runner: Runner, parameters: RunnerHandlerParameters): bool
 
 	const conditionPass = runner.condition?.(file)
 	const patternMatch = patterns.some((pattern) => {
-		pattern = path.resolve(parameters.server.config.root, pattern)
+		pattern = path.resolve(parameters.server.config.root, pattern).replaceAll('\\', '/')
 
 		if (minimatch(file, pattern)) {
 			debug.runner(name, `pattern ${pattern} matched for ${c.gray(parameters.file)}`)


### PR DESCRIPTION
vite version: v4.2.1
vite-plugin-watch: v0.4.0

When changing files on Windows 11, the command won't be triggered as the path doesn't match.