### PR TITLE
fix: gracefully handle failures

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -151,8 +151,16 @@ function handleRunnerCommand(options: ResolvedRunOptions, runner: Runner) {
 		const { stdout, stderr, failed, exitCode } = await execa(
 			getExecutable(options, getRunnerCommand(runner)),
 			getRunnerArguments(runner),
-			{ stdout: options.silent ? 'ignore' : 'pipe', stderr: options.silent ? 'ignore' : 'pipe' },
+			{
+				stdout: options.silent ? 'ignore' : 'pipe',
+				stderr: options.silent ? 'ignore' : 'pipe',
+				reject: false,
+			},
 		)
+
+		if (failed && !options.silent) {
+			console.error(`[Vite Plugin Run] failed to run: [${name}] with code ${exitCode}`)
+		}
 
 		if (stdout && !options.silent) {
 			process.stdout.write(stdout)

--- a/src/run.ts
+++ b/src/run.ts
@@ -158,10 +158,6 @@ function handleRunnerCommand(options: ResolvedRunOptions, runner: Runner) {
 			},
 		)
 
-		if (failed && !options.silent) {
-			console.error(`[Vite Plugin Run] failed to run: [${name}] with code ${exitCode}`)
-		}
-
 		if (stdout && !options.silent) {
 			process.stdout.write(stdout)
 		}


### PR DESCRIPTION
This uses the `reject` option on execa to ensure that commands that fail are surpassed so vite server can continue to operate.

It will respect the `silent` option and supress the warnings.

reference: https://github.com/sindresorhus/execa/blob/main/docs/errors.md#preventing-exceptions

This should be useful as most of the time the commands are used for generators, and non-critical executions.

Example: a PHP file command executed returned a exit code 1, shouldnt stop the vite dev server.