### PR TITLE
fix: remove custom processing of command output

### DIFF
--- a/src/run.ts
+++ b/src/run.ts
@@ -153,19 +153,11 @@ function handleRunnerCommand(options: ResolvedRunOptions, runner: Runner) {
 			getExecutable(options, getRunnerCommand(runner)),
 			getRunnerArguments(runner),
 			{
-				stdout: options.silent ? 'ignore' : 'pipe',
-				stderr: options.silent ? 'ignore' : 'pipe',
+				stdout: options.silent ? 'ignore' : 'inherit',
+				stderr: options.silent ? 'ignore' : 'inherit',
 				reject: false,
 			},
 		)
-
-		if (stdout && !options.silent) {
-			process.stdout.write(stdout)
-		}
-
-		if (stdout && !options.silent) {
-			process.stdout.write(stderr)
-		}
 
 		debug.runner(name, stdout)
 		debug.runner(name, stderr)

--- a/src/run.ts
+++ b/src/run.ts
@@ -149,7 +149,7 @@ function handleRunnerCommand(options: ResolvedRunOptions, runner: Runner) {
 	// Runs the runner after the configured delay
 	debug.runner(name, 'Running...')
 	setTimeout(async () => {
-		const { stdout, stderr, failed, exitCode } = await execa(
+		const { failed, exitCode } = await execa(
 			getExecutable(options, getRunnerCommand(runner)),
 			getRunnerArguments(runner),
 			{
@@ -159,8 +159,6 @@ function handleRunnerCommand(options: ResolvedRunOptions, runner: Runner) {
 			},
 		)
 
-		debug.runner(name, stdout)
-		debug.runner(name, stderr)
 		debug.runner(name, !failed ? 'Ran successfully.' : `Failed with code ${exitCode}.`)
 	}, runner.delay ?? 50)
 }


### PR DESCRIPTION
This removes the processing of output streams, instead opting to let subprocesses inherit Vite's stdio. This fixes two issues:
1. When a given command only writes to stderr, no output is forwarded to Vite ([due to checking stdout's trutieness before writing stderr](https://github.com/innocenzi/vite-plugin-run/blob/main/src/run.ts#L166)).
2. Most commands turn off color output because they detect that their output is being fed to a process first.